### PR TITLE
chore: adds ci.yml for continous integration in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 on:
   pull_request:
-  branches:
-    - main
+    branches:
+      - master
 
 jobs:
   flutter_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  pull_request:
+  branches:
+    - main
+
+jobs:
+  flutter_test:
+    name: Run flutter test and analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "12.x"
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: "stable"
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test


### PR DESCRIPTION
# Description of the problem
Right now we don't have any checks on whether the previous unit/intergration tests are still working or not.


## How does it solve the problem
This will introduce an automated job that will format and analyze the code, as well as run a dedicated pipeline in Java to check tests integrity.

# References (also the Jira ticket)
[BAR-1](https://unboolean.atlassian.net/jira/software/projects/BAR/boards/3?selectedIssue=BAR-1)

# Checklist:

- [ ] I re-reviewed the Jira ticket now to make sure 
- [ ] My code follows the style guidelines of this project & of Dart
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have wrote some documentation if I changed a big behavior of the code
- [ ] My changes generate no new warnings/and if they do, I described them to the team
- [ ] I have added tests that prove my fix is effective or that my feature works if I worked on a logic class/function
- [ ] New and existing unit and integration tests pass locally with my changes
